### PR TITLE
Add support for Dict fields

### DIFF
--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -145,6 +145,8 @@ def _convert_field(field: pydantic.fields.ModelField) -> serializers.Field:
     ), f"Unsupported container type '{field.outer_type_.__name__}'"
     if field.outer_type_.__origin__ is list or field.outer_type_.__origin__ is tuple:
         return serializers.ListField(child=_convert_type(field.type_)(**extra_kwargs))
+    if field.outer_type_._name == 'Dict':
+        return serializers.DictField(child=serializers.Field())
     raise NotImplementedError(
         f"Container type '{field.outer_type_.__origin__.__name__}' is not yet supported"
     )


### PR DESCRIPTION
This is by no means a completed PR (I haven't added tests and it just sets dict fields to generic field dicts), but I wanted to use it to open a discussion around supporting generic dict fields.

I have an API where one field is a dictionary whose type is unknown to the service itself, it's basically proxying it from a third party service to the API consumer, and typing it isn't really an option so I'd just like the serializer to know that it's going to be a dict of some sort.