### PR TITLE
Add `allow_blank` support for serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,5 @@ Block.drf_serializer
 
 # Roadmap
 
-- Add `ENUM` support
 - Add option to create custom serializer for complex models
 - Add support for constraints (max, min, regex, etc.)

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ MyModel.drf_serializer
 ```
 
 > ℹ️ **INFO**<br>
-> Models created using `drf_pydantic` are fully idenditcal to those created by
+> Models created using `drf_pydantic` are fully identical to those created by
 > `pydantic`. The only change is the addition of the `drf_serializer` attribute
 > during class creation (not instance).
 
 ## Existing Models
 
-If you have an existing code base and you would like to use the `drf_serializer`
+If you have an existing code base, and you would like to use the `drf_serializer`
 attribute to only specific models, then great news 🥳 - you can easily extend
-your existign `pydantic` models by adding `drf_pydantic.BaseModel` to the list
+your existing `pydantic` models by adding `drf_pydantic.BaseModel` to the list
 of parent classes.
 
 Your existing pydantic models:

--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -96,6 +96,8 @@ def _convert_field(field: pydantic.fields.ModelField) -> serializers.Field:
         extra_kwargs["required"] = field.required
     if field.default is not None:
         extra_kwargs["default"] = field.default
+        if field.default == '':
+            extra_kwargs["allow_blank"] = True
     if field.allow_none:
         extra_kwargs["allow_null"] = True
         extra_kwargs["default"] = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -386,29 +386,49 @@ def test_enum_value():
 def test_allow_blank():
     class Human(BaseModel):
         name: str
-        bio: str = Field(default="")
+        bio: str = Field(
+            default="",
+        )
+        address: str = Field(allow_blank=True)
+        town: str = Field(allow_blank=False)
         age: int
 
     serializer = Human.drf_serializer()
 
     assert isinstance(serializer.fields["name"], serializers.CharField)
     assert isinstance(serializer.fields["bio"], serializers.CharField)
+    assert isinstance(serializer.fields["address"], serializers.CharField)
+    assert isinstance(serializer.fields["town"], serializers.CharField)
     assert isinstance(serializer.fields["age"], serializers.IntegerField)
-    assert not serializer.fields["name"].allow_blank
+    assert serializer.fields["name"].allow_blank is False
+    assert serializer.fields["town"].allow_blank is False
     assert serializer.fields["bio"].allow_blank
+    assert serializer.fields["address"].allow_blank
 
-    blank_serializer = Human.drf_serializer(data={"name": "Bob", "bio": "", "age": 25})
+    blank_serializer = Human.drf_serializer(
+        data={"name": "Bob", "bio": "", "address": "", "town": "somewhere", "age": 25}
+    )
 
     assert blank_serializer.is_valid()
     assert blank_serializer.validated_data["name"] == "Bob"
     assert blank_serializer.validated_data["bio"] == ""
+    assert blank_serializer.validated_data["address"] == ""
+    assert blank_serializer.validated_data["town"] == "somewhere"
     assert blank_serializer.validated_data["age"] == 25
 
     value_serializer = Human.drf_serializer(
-        data={"name": "Bob", "bio": "This is my bio", "age": 25}
+        data={
+            "name": "Bob",
+            "bio": "This is my bio",
+            "address": "1234, some road",
+            "town": "somewhere",
+            "age": 25,
+        }
     )
 
     assert value_serializer.is_valid()
     assert value_serializer.validated_data["name"] == "Bob"
     assert value_serializer.validated_data["bio"] == "This is my bio"
+    assert value_serializer.validated_data["address"] == "1234, some road"
+    assert value_serializer.validated_data["town"] == "somewhere"
     assert value_serializer.validated_data["age"] == 25

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -386,9 +386,7 @@ def test_enum_value():
 def test_allow_blank():
     class Human(BaseModel):
         name: str
-        bio: str = Field(
-            default="",
-        )
+        bio: str = ""
         address: str = Field(allow_blank=True)
         town: str = Field(allow_blank=False)
         age: int
@@ -403,6 +401,7 @@ def test_allow_blank():
     assert serializer.fields["name"].allow_blank is False
     assert serializer.fields["town"].allow_blank is False
     assert serializer.fields["bio"].allow_blank
+    assert serializer.fields["bio"].default == ""
     assert serializer.fields["address"].allow_blank
 
     blank_serializer = Human.drf_serializer(


### PR DESCRIPTION
Proposal to add the ability to specify `allow_blank` on serializer fields.

There are two ways this is achieved:

1: Define the default of a field as `""` which will automatically add `allow_blank` to the serializer field.

```python
class Person(BaseModel):
    name: str = ''
```

2. Provide the Field class to a field in the pydantic model with `allow_blank` set to True (or False if you want)

```python
class Person(BaseModel):
    name: str = Field(allow_blank=True)
    # You can also provide default etc in the Field as well
    surname: str = Field(default='', allow_blank=True)  
```

Don't know if you want to add something to the readme to explain these changes or not.

Let me know what you think