### PR TITLE
Add label from title

### DIFF
--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -142,6 +142,13 @@ def _convert_field(field: pydantic.fields.FieldInfo) -> serializers.Field:
     ):
         drf_field_kwargs["help_text"] = field.description
 
+    # Adding label as title
+    if (
+            field.title is not pydantic_core.PydanticUndefined
+            and field.title is not None
+    ):
+        drf_field_kwargs["label"] = field.title
+
     # Process constraints
     for item in field.metadata:
         if isinstance(item, pydantic.StringConstraints):

--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -144,8 +144,8 @@ def _convert_field(field: pydantic.fields.FieldInfo) -> serializers.Field:
 
     # Adding label as title
     if (
-            field.title is not pydantic_core.PydanticUndefined
-            and field.title is not None
+        field.title is not pydantic_core.PydanticUndefined
+        and field.title is not None
     ):
         drf_field_kwargs["label"] = field.title
 

--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -143,10 +143,7 @@ def _convert_field(field: pydantic.fields.FieldInfo) -> serializers.Field:
         drf_field_kwargs["help_text"] = field.description
 
     # Adding label as title
-    if (
-        field.title is not pydantic_core.PydanticUndefined
-        and field.title is not None
-    ):
+    if field.title is not pydantic_core.PydanticUndefined and field.title is not None:
         drf_field_kwargs["label"] = field.title
 
     # Process constraints

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -575,6 +575,7 @@ def test_drf_field_kwargs():
         field_7: typing.Optional[str] = None
         field_8: typing.Annotated[str, pydantic.Field(description="8th field")]
         field_9: str = pydantic.Field(default="default", description="9th field")
+        field_10: str = pydantic.Field(default="default", title="10th field")
 
     serializer = Person.drf_serializer()
 
@@ -606,6 +607,8 @@ def test_drf_field_kwargs():
     assert serializer.fields["field_7"].help_text is None
     assert serializer.fields["field_8"].help_text == "8th field"
     assert serializer.fields["field_9"].help_text == "9th field"
+
+    assert serializer.fields["field_10"].label == "10th field"
 
 
 class TestManualFields:

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -576,6 +576,7 @@ def test_drf_field_kwargs():
         field_8: typing.Annotated[str, pydantic.Field(description="8th field")]
         field_9: str = pydantic.Field(default="default", description="9th field")
         field_10: str = pydantic.Field(default="default", title="10th field")
+        field_11: typing.Annotated[str, pydantic.Field(title="11th field")]
 
     serializer = Person.drf_serializer()
 
@@ -608,7 +609,13 @@ def test_drf_field_kwargs():
     assert serializer.fields["field_8"].help_text == "8th field"
     assert serializer.fields["field_9"].help_text == "9th field"
 
+    # Field 8, Field 9 is automatically generated label
+    assert serializer.fields["field_8"].label == "Field 8"
+    assert serializer.fields["field_9"].label == "Field 9"
+
+    # This is custom defined label
     assert serializer.fields["field_10"].label == "10th field"
+    assert serializer.fields["field_11"].label == "11th field"
 
 
 class TestManualFields:


### PR DESCRIPTION
Hello! I'm using your drf-pydantic library to use pydantic model in my django project!

It is very good for cleaning my code, but I found that there is no method to set label in drf_field from drf-pydantic model.

So, I have a request.

What about changing title of pydantic model into label in drf_field? I want to change label field so that I can use it in from drf_yasg.utils import swagger_auto_schema

something like 
```python
class DrfPydanticModel(BaseModel):
    test_field: int = Field(..., title="custom title")


@swagger_auto_schema(
    method="post",
    request_body=DrfPydanticModel.drf_serializer,
)
```
so that I can auto-generate swagger(redoc) page
![image](https://github.com/user-attachments/assets/9bd1be2d-fa4c-4e60-a202-b338835a5b02)

