### PR TITLE
Add list constraints

### DIFF
--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -11,6 +11,7 @@ import pydantic
 import pydantic.fields
 import pydantic_core
 
+from annotated_types import MaxLen, MinLen
 from pydantic._internal._fields import PydanticMetadata
 from rest_framework import serializers  # type: ignore
 from typing_extensions import TypeAliasType
@@ -157,6 +158,24 @@ def _convert_field(field: pydantic.fields.FieldInfo) -> serializers.Field:
                 if item.min_length is not None
                 else drf_field_kwargs.get("min_length", None)
             )
+            drf_field_kwargs["max_length"] = (
+                min(
+                    drf_field_kwargs.get("max_length", float("inf")),
+                    item.max_length,
+                )
+                if item.max_length is not None
+                else drf_field_kwargs.get("max_length", None)
+            )
+        elif isinstance(item, MinLen):
+            drf_field_kwargs["min_length"] = (
+                max(
+                    drf_field_kwargs.get("min_length", float("-inf")),
+                    item.min_length,
+                )
+                if item.min_length is not None
+                else drf_field_kwargs.get("min_length", None)
+            )
+        elif isinstance(item, MaxLen):
             drf_field_kwargs["max_length"] = (
                 min(
                     drf_field_kwargs.get("max_length", float("inf")),

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -45,6 +45,15 @@ class TestScalar:
         assert serializer.fields["name"].min_length == 3
         assert serializer.fields["name"].max_length == 10
 
+    def test_constrained_list(self):
+        class Person(BaseModel):
+            name: list[int] = pydantic.Field(min_length=3, max_length=10)
+
+        serializer = Person.drf_serializer()
+        assert isinstance(serializer.fields["name"], serializers.ListField)
+        assert serializer.fields["name"].min_length == 3
+        assert serializer.fields["name"].max_length == 10
+
     def test_email(self):
         class Person(BaseModel):
             email: pydantic.EmailStr

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -45,6 +45,16 @@ class TestScalar:
         assert serializer.fields["name"].min_length == 3
         assert serializer.fields["name"].max_length == 10
 
+    def test_constrained_string_defined_from_field(self):
+        class Person(BaseModel):
+            name: str = pydantic.Field(min_length=3, max_length=10)
+
+        serializer = Person.drf_serializer()
+
+        assert isinstance(serializer.fields["name"], serializers.CharField)
+        assert serializer.fields["name"].min_length == 3
+        assert serializer.fields["name"].max_length == 10
+
     def test_constrained_list(self):
         class Person(BaseModel):
             name: list[int] = pydantic.Field(min_length=3, max_length=10)


### PR DESCRIPTION
Hello again! 
I found that pydantic constraints on list/string doesn't seem to work well if I define it in pydantic.Field.

```python
from drf_pydantic import BaseModel
from pydantic import Field


class Test(BaseModel):
    test_list: list[float] = Field(default=5, title="test", max_length=3)
    test_str: str = Field(default="", max_length=3)


if __name__ == "__main__":
    print(Test(test_list= [1,2,3]).drf_serializer.__dict__)
```

This is my test code.

So, I refined this to work well on Field.
Moreover, https://github.com/pydantic/pydantic/issues/8771 shows that this constraints also applies to list. 

Many thanks!