### PR TITLE
Fix regex pattern mapping and allow_blank behavior for special fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ class MyModel(BaseModel):
 
 ```python
 class MyModelSerializer:
-    name = CharField(allow_null=False, required=True)
+    name = CharField(allow_null=False, required=True, allow_blank=True)
     addresses = ListField(
         allow_empty=True,
         allow_null=False,
-        child=CharField(allow_null=False),
+        child=CharField(allow_null=False, allow_blank=True),
         required=True,
     )
 ```
@@ -370,7 +370,7 @@ Additional field properties are mapped as follows (`pydantic` -> `DRF`):
 
 - `description` -> `help_text`
 - `title` -> `label`
-- `StringConstraints` -> `min_length` and `max_length`
+- `StringConstraints` -> `min_length` and `max_length` and `allow_blank`
 - `pattern` -> Uses the specialized `RegexField` serializer field
 - `max_digits` and `decimal_places` are carried over
   (used for `Decimal` types, with the current decimal context precision)

--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -391,12 +391,22 @@ def _convert_type(  # noqa: PLR0911
                     f"Field has multiple regex patterns: {regex_patterns}"
                 )
             elif len(regex_patterns) == 1:
-                return serializers.RegexField(regex=regex_patterns[0], **kwargs)
+                pattern = regex_patterns[0]
+                if isinstance(pattern, re.Pattern):
+                    kwargs["allow_blank"] = pattern.search("") is not None
+                elif isinstance(pattern, str):
+                    kwargs["allow_blank"] = re.search(pattern, "") is not None
+                return serializers.RegexField(regex=pattern, **kwargs)
         # Enum
         elif issubclass(type_, enum.Enum):
             return serializers.ChoiceField(
                 choices=[(item.value, item.value) for item in type_], **kwargs
             )
+        # String allow_blank handling
+        if issubclass(type_, (pydantic.EmailStr, pydantic_core.Url, pydantic.HttpUrl)):
+            kwargs["allow_blank"] = False
+        elif issubclass(type_, str):
+            kwargs["allow_blank"] = kwargs.get("min_length", 0) == 0
         # Known mapped scalar field
         for key in getattr(type_, "__mro__", []):
             try:

--- a/src/drf_pydantic/parse.py
+++ b/src/drf_pydantic/parse.py
@@ -358,7 +358,7 @@ def _convert_type(  # noqa: PLR0911
         if issubclass(type_, pydantic.BaseModel):
             return create_serializer_from_model(type_, drf_config=drf_config)(**kwargs)
         # Decimal
-        elif type_ is decimal.Decimal:
+        if type_ is decimal.Decimal:
             _context = decimal.getcontext()
             kwargs["max_digits"] = kwargs.get("max_digits", None) or _context.prec
             kwargs["decimal_places"] = (
@@ -367,7 +367,11 @@ def _convert_type(  # noqa: PLR0911
             return serializers.DecimalField(**kwargs)
         # Regex
         elif field is not None and any(
-            isinstance(item, pydantic.StringConstraints) and item.pattern is not None
+            (isinstance(item, pydantic.StringConstraints) and item.pattern is not None)
+            or (
+                isinstance(item, PydanticMetadata)
+                and getattr(item, "pattern", None) is not None
+            )
             for item in field.metadata
         ):
             regex_patterns: List[Union[str, re.Pattern[str]]] = []
@@ -377,6 +381,11 @@ def _convert_type(  # noqa: PLR0911
                     and item.pattern is not None
                 ):
                     regex_patterns.append(item.pattern)
+                elif (
+                    isinstance(item, PydanticMetadata)
+                    and getattr(item, "pattern", None) is not None
+                ):
+                    regex_patterns.append(getattr(item, "pattern"))
             if len(regex_patterns) > 1:
                 raise FieldConversionError(
                     f"Field has multiple regex patterns: {regex_patterns}"


### PR DESCRIPTION
Hi! Here is a PR regarding #44.

I noticed that fields with a `pattern` set weren't converting to `RegexField` as expected, so I tried fixing that.

I also updated special fields like `EmailStr` and `HttpUrl` to set `allow_blank=False`. This aligns them better with Pydantic's default behavior.

Please take a look! This is my first time contributing to an OSS project, so apologies in advance if I missed any conventions or made any mistakes. Thanks!